### PR TITLE
Added TimeDefinition class, from_simplicity() and to_csv()

### DIFF
--- a/mapping.txt
+++ b/mapping.txt
@@ -1,5 +1,5 @@
 AccumulatedAnnualDemand.csv                       -> Commodity.annual_demand
-AnnualEmissionLimit.csv                           -> Impact.constaint
+AnnualEmissionLimit.csv                           -> Impact.constraint
 AnnualExogenousEmission.csv                       -> Impact.exogenous
 AvailabilityFactor.csv                            -> Technology.AvailabilityFactor.
 CapacityFactor.csv                                -> Technology.CapacityFactor
@@ -34,7 +34,7 @@ OutputActivityRatio.csv                           -> Technology.op_mode[].output
 _REGION.csv                                       -> Region
 REGION.csv                                        -> Region
 REMinProductionTarget.csv                         -> Model.renewable_target
-ReserveMargin.csv                                 -> Model.reserve_margin_X
+ReserveMargin.csv                                 -> Model.reserve_margin_level
 ReserveMarginTagFuel.csv                          -> Model.reserve_margin_commodity
 ReserveMarginTagTechnology.csv                    -> Model.reserve_margin_technology
 ResidualCapacity.csv                              -> Technology.residual_capacity

--- a/src/osemosys/schemas/base.py
+++ b/src/osemosys/schemas/base.py
@@ -69,11 +69,42 @@ class RegionYearData(BaseModel):
         Dict[str,Dict[int,float]]
     ]
 
+class StringYearData(BaseModel):
+    # can be expressed as:
+    #  - one value
+    #  - a dict of year:value OR region:value
+    #  - a dict of region:{year:value}
+    data: Union[
+        Union[float,int],
+        Dict[Union[str,int], Union[float,int]],
+        Dict[str,Dict[int,Union[float,int]]]
+    ]
+
+class IntYearData(BaseModel):
+    # can be expressed as:
+    #  - one integer value
+    #  - a dict of year:value OR integer:value
+    #  - a dict of int:{year:value}
+    data: Union[
+        Union[float,int],
+        Dict[int, Union[float,int]],
+        Dict[int,Dict[int,Union[float,int]]]
+    ]
+
+class IntIntIntData(BaseModel):
+    # can be expressed as:
+    #  - integer or float value with 0-3 additional integers
+    data: Union[
+        Union[int,float],
+        Dict[int, Union[int,float]],
+        Dict[int,Dict[int,Union[int,float]]],
+        Dict[int,Dict[int,Dict[int,Union[int,float]]]]
+    ]
+
 class RegionYearTimeData(BaseModel):
     # can be expressed as:
     #  - one value
-    #  - a dict of region:value
-    #  - a dict of timeslice:value
+    #  - a dict of region:value OR timeslice:value
     #  - a dict of region:year:value
     #  - a dict of region:timeslice:value
     #  - a dict of region:{year:{timeslice:value}}
@@ -82,8 +113,9 @@ class RegionYearTimeData(BaseModel):
         Dict[str, float], # which one? ambiguous
         Dict[str, Dict[int, float]],
         Dict[str, Dict[str, float]],
-        Dict[str, Dict[int, Dict[str, float]]]
+        Dict[str, Dict[str, Dict[int, float]]]
     ]
+
 class RegionCommodityYearData(BaseModel):
     # can be expressed as:
     #  - one value
@@ -95,5 +127,4 @@ class RegionCommodityYearData(BaseModel):
         Dict[Union[str,int], float],
         Dict[str,Dict[Union[str,int],float]],
         Dict[str,Dict[str,Dict[int,float]]]
-
     ]

--- a/src/osemosys/schemas/commodity.py
+++ b/src/osemosys/schemas/commodity.py
@@ -14,7 +14,7 @@ class Commodity(OSeMOSYSBase):
     is_renewable: RegionYearData | None # why would this change over time??
 
     @classmethod
-    def from_simplicity(cls, root_dir) -> List["cls"]:
+    def from_otoole_csv(cls, root_dir) -> List["cls"]:
 
         # 
         df_fuel = pd.read_csv(os.path.join(root_dir, 'FUEL.csv'))

--- a/src/osemosys/schemas/impact.py
+++ b/src/osemosys/schemas/impact.py
@@ -22,14 +22,14 @@ class Impact(OSeMOSYSBase):
 
 
     @classmethod
-    def from_simplicity(cls, root_dir) -> List["cls"]:
+    def from_otoole_csv(cls, root_dir) -> List["cls"]:
         """
         Instantiate a number of Impact objects from otoole-organised csvs.
 
         Parameters
         ----------
         root_dir: str
-            Path to the root of the simplicity directory
+            Path to the root of the otoole csv directory
 
         Returns
         -------

--- a/src/osemosys/schemas/model.py
+++ b/src/osemosys/schemas/model.py
@@ -8,7 +8,7 @@ from .time_definition import *
 from .region import *
 from .commodity import *
 from .impact import *
-from .technology import *
+#from .technology import *
 
 
 class RunSpec(OSeMOSYSBase):
@@ -46,7 +46,7 @@ class RunSpec(OSeMOSYSBase):
     # Default values
     #TODO
 
-    def to_csv(self, comparison_directory) -> Dict[str,str]:
+    def to_otoole_csv(self, comparison_directory) -> Dict[str,str]:
         """
         Dump regions to 
 
@@ -60,12 +60,12 @@ class RunSpec(OSeMOSYSBase):
         Dict[str,str]
             A dictionary with keys the otool filenames and paths the otool paths
         """
-        self.time_definition.to_csv(comparison_directory, self.time_definition)
+        self.time_definition.to_otoole_csv(comparison_directory, self.time_definition)
         
         pass
 
     @classmethod
-    def from_simplicity(cls, root_dir) -> "cls":
+    def from_otoole_csv(cls, root_dir) -> "cls":
 
         def get_depreciation_method(root_dir):
             df = pd.read_csv(os.path.join(root_dir, 'DepreciationMethod.csv'))
@@ -105,14 +105,14 @@ class RunSpec(OSeMOSYSBase):
             description = None,
             depreciation_method = depreciation_method,
             discount_rate=discount_rate,
-            impacts=Impact.from_simplicity(root_dir=root_dir),
-            regions=Region.from_simplicity(root_dir=root_dir),
+            impacts=Impact.from_otoole_csv(root_dir=root_dir),
+            regions=Region.from_otoole_csv(root_dir=root_dir),
             #TODO
-            #production_technologies=TechnologyProduction.from_simplicity(root_dir=root_dir),
-            #storage_technologies=TechnologyStorage.from_simplicity(root_dir=root_dir),
-            #transmission_technologies=TechnologyTransmission.from_simplicity(root_dir=root_dir),
-            commodities=Commodity.from_simplicity(root_dir=root_dir),
-            time_definition=TimeDefinition.from_simplicity(root_dir=root_dir),
+            #production_technologies=TechnologyProduction.from_otoole_csv(root_dir=root_dir),
+            #storage_technologies=TechnologyStorage.from_otoole_csv(root_dir=root_dir),
+            #transmission_technologies=TechnologyTransmission.from_otoole_csv(root_dir=root_dir),
+            commodities=Commodity.from_otoole_csv(root_dir=root_dir),
+            time_definition=TimeDefinition.from_otoole_csv(root_dir=root_dir),
             reserve_margins_level=reserve_margins_level, 
             reserve_margins_commodity=reserve_margins_commodity,
             reserve_margins_technology=reserve_margins_technology,

--- a/src/osemosys/schemas/model.py
+++ b/src/osemosys/schemas/model.py
@@ -46,7 +46,7 @@ class RunSpec(OSeMOSYSBase):
     # Default values
     #TODO
 
-    def to_simplicity(self, comparison_directory) -> Dict[str,str]:
+    def to_csv(self, comparison_directory) -> Dict[str,str]:
         """
         Dump regions to 
 
@@ -60,7 +60,7 @@ class RunSpec(OSeMOSYSBase):
         Dict[str,str]
             A dictionary with keys the otool filenames and paths the otool paths
         """
-        self.commodities.to_simplicity(comparison_directory)
+        self.time_definition.to_csv(comparison_directory, self.time_definition)
         
         pass
 

--- a/src/osemosys/schemas/model.py
+++ b/src/osemosys/schemas/model.py
@@ -15,11 +15,10 @@ class RunSpec(OSeMOSYSBase):
 
     # financials
     depreciation_method: RegionData | None # 1= "straight-line" # or "sinking-fund"
-    discount_rate: RegionTechnologyYearData | None # may want to express this at the technology or model level
+    discount_rate: RegionData | None # may want to express this at the technology or model level
 
     # time definition
-    #TODO
-    #time_definition: TimeDefinition
+    time_definition: TimeDefinition
 
     # nodes
     regions: List[Region]
@@ -28,8 +27,7 @@ class RunSpec(OSeMOSYSBase):
     commodities: List[Commodity]
 
     # impact constraints (e.g. CO2)
-    #TODO
-    #impacts: List[Impact]
+    impacts: List[Impact]
 
     # technologies
     #TODO
@@ -38,12 +36,15 @@ class RunSpec(OSeMOSYSBase):
     #transmission_technologies: List[TechnologyTransmission]
 
     # reserve margins if any
-    reserve_margins_commodity: List[Dict[str,RegionYearData]] | None
-    reserve_margins_technology: List[Dict[str, RegionYearData]] | None
+    reserve_margins_level: RegionYearData | None
+    reserve_margins_commodity: RegionCommodityYearData | None
+    reserve_margins_technology: RegionTechnologyYearData | None
 
     # renewable targets
     renewable_targets: RegionYearData | None
     
+    # Default values
+    #TODO
 
     def to_simplicity(self, comparison_directory) -> Dict[str,str]:
         """
@@ -68,20 +69,31 @@ class RunSpec(OSeMOSYSBase):
 
         def get_depreciation_method(root_dir):
             df = pd.read_csv(os.path.join(root_dir, 'DepreciationMethod.csv'))
-            
-
+            return df if not df.empty else None 
+        
         def get_discount_rate(root_dir):
-            None
+            df = pd.read_csv(os.path.join(root_dir, 'DiscountRate.csv'))
+            return df if not df.empty else None
+        
+        def get_reserve_margins_level(root_dir):
+            df = pd.read_csv(os.path.join(root_dir, 'ReserveMargin.csv'))
+            return df if not df.empty else None
+        
         def get_reserve_margins_commodity(root_dir):
-            None
+            df = pd.read_csv(os.path.join(root_dir, 'ReserveMarginTagFuel.csv'))
+            return df if not df.empty else None
+        
         def get_reserve_margins_technology(root_dir):
-            None
+            df = pd.read_csv(os.path.join(root_dir, 'ReserveMarginTagTechnology.csv'))
+            return df if not df.empty else None
+        
         def get_renewable_targets(root_dir):
-            None
+            df = pd.read_csv(os.path.join(root_dir, 'REMinProductionTarget.csv'))
+            return df if not df.empty else None
 
-        # depreciation method
         depreciation_method = get_depreciation_method(root_dir)
         discount_rate = get_discount_rate(root_dir)
+        reserve_margins_level = get_reserve_margins_level(root_dir)
         reserve_margins_commodity = get_reserve_margins_commodity(root_dir)
         reserve_margins_technology = get_reserve_margins_technology(root_dir)
         renewable_targets = get_renewable_targets(root_dir)
@@ -93,12 +105,15 @@ class RunSpec(OSeMOSYSBase):
             description = None,
             depreciation_method = depreciation_method,
             discount_rate=discount_rate,
+            impacts=Impact.from_simplicity(root_dir=root_dir),
             regions=Region.from_simplicity(root_dir=root_dir),
             #TODO
             #production_technologies=TechnologyProduction.from_simplicity(root_dir=root_dir),
             #storage_technologies=TechnologyStorage.from_simplicity(root_dir=root_dir),
             #transmission_technologies=TechnologyTransmission.from_simplicity(root_dir=root_dir),
             commodities=Commodity.from_simplicity(root_dir=root_dir),
+            time_definition=TimeDefinition.from_simplicity(root_dir=root_dir),
+            reserve_margins_level=reserve_margins_level, 
             reserve_margins_commodity=reserve_margins_commodity,
             reserve_margins_technology=reserve_margins_technology,
             renewable_targets=renewable_targets

--- a/src/osemosys/schemas/region.py
+++ b/src/osemosys/schemas/region.py
@@ -14,14 +14,14 @@ class Region(OSeMOSYSBase):
     neighbours: Optional[List[str]]
 
     @classmethod
-    def from_simplicity(cls, root_dir) -> List["cls"]:
+    def from_otoole_csv(cls, root_dir) -> List["cls"]:
         """
         Instantiate a number of Region objects from otoole-organised csvs.
 
         Parameters
         ----------
         root_dir: str
-            Path to the root of the simplicity directory
+            Path to the root of the otoole csv directory
 
         Returns
         -------

--- a/src/osemosys/schemas/time_definition.py
+++ b/src/osemosys/schemas/time_definition.py
@@ -26,14 +26,14 @@ class TimeDefinition(OSeMOSYSBase):
 
 
     @classmethod
-    def from_simplicity(cls, root_dir) -> "cls":
+    def from_otoole_csv(cls, root_dir) -> "cls":
         """
         Instantiate a single TimeDefinition object containing all relevant data from otoole-organised csvs.
 
         Parameters
         ----------
         root_dir: str
-            Path to the root of the simplicity directory
+            Path to the root of the otoole csv directory
 
         Returns
         -------
@@ -127,7 +127,7 @@ class TimeDefinition(OSeMOSYSBase):
                     )
 
     @classmethod
-    def to_csv(cls, comparison_directory, time_definition) -> "cls":
+    def to_otoole_csv(cls, comparison_directory, time_definition) -> "cls":
         
         ### Write sets to csv
 

--- a/src/osemosys/schemas/time_definition.py
+++ b/src/osemosys/schemas/time_definition.py
@@ -4,7 +4,7 @@ import pandas as pd
 from .base import *
 from osemosys.utils import *
 
-class TimeDefinition(BaseModel):
+class TimeDefinition(OSeMOSYSBase):
     """
     Class to contain all temporal information, including years and timeslices.
     """

--- a/src/osemosys/schemas/time_definition.py
+++ b/src/osemosys/schemas/time_definition.py
@@ -5,11 +5,129 @@ from .base import *
 from osemosys.utils import *
 
 class TimeDefinition(BaseModel):
-    years: Union[str,List[int]]
+    """
+    Class to contain all temporal information, including years and timeslices.
+    """
+    
+    # Sets
+    years: List[int]
+    season: List[int]
+    timeslice: List[str]
+    day_type: List[int]
+    daily_time_bracket: List[int]
+    # Parameters
+    year_split: StringYearData | None
+    day_split: IntYearData | None
+    days_in_day_type: IntIntIntData | None
+    conversion_ld: StringYearData | None
+    conversion_lh: StringYearData | None
+    conversion_ls: StringYearData | None
 
 
 
     @classmethod
-    def from_simplicity(cls, root_dir):
-        None
-        
+    def from_simplicity(cls, root_dir) -> "cls":
+        """
+        Instantiate a single TimeDefinition object containing all relevant data from otoole-organised csvs.
+
+        Parameters
+        ----------
+        root_dir: str
+            Path to the root of the simplicity directory
+
+        Returns
+        -------
+        TimeDefinition
+            A single TimeDefinition instance that can be used downstream or dumped to json/yaml
+        """
+        # Sets
+        df_years = pd.read_csv(os.path.join(root_dir, 'YEAR.csv'))
+        df_season = pd.read_csv(os.path.join(root_dir, 'SEASON.csv'))
+        df_timeslice = pd.read_csv(os.path.join(root_dir, 'TIMESLICE.csv'))
+        df_day_type = pd.read_csv(os.path.join(root_dir, 'DAYTYPE.csv'))
+        df_daily_time_bracket = pd.read_csv(os.path.join(root_dir, 'DAILYTIMEBRACKET.csv'))
+
+        # Parameters
+        df_year_split = pd.read_csv(os.path.join(root_dir, 'YearSplit.csv'))
+        df_day_split = pd.read_csv(os.path.join(root_dir, 'DaySplit.csv'))
+        df_days_in_day_type = pd.read_csv(os.path.join(root_dir, 'DaysInDayType.csv'))
+        df_conversion_ld = pd.read_csv(os.path.join(root_dir, 'Conversionld.csv'))
+        df_conversion_lh = pd.read_csv(os.path.join(root_dir, 'Conversionlh.csv'))
+        df_conversion_ls = pd.read_csv(os.path.join(root_dir, 'Conversionls.csv'))
+
+        # Assert days in day type values <=7
+        assert df_days_in_day_type["VALUE"].isin([1,2,3,4,5,6,7]).all(), "Days in day type can only take values from 1-7"
+
+        return cls(
+                    id="TimeDefinition",
+                    #TODO
+                    long_name = None,
+                    description = None,
+                    # Sets
+                    years = df_years["VALUE"].values.tolist(),
+                    season = df_season["VALUE"].values.tolist(),
+                    timeslice = df_timeslice["VALUE"].values.tolist(),
+                    day_type = df_day_type["VALUE"].values.tolist(),
+                    daily_time_bracket = df_daily_time_bracket["VALUE"].values.tolist(),
+                    # Parameters
+                    year_split = (
+                        StringYearData(
+                            data=group_to_json(
+                                g=df_year_split,
+                                root_column='TIMESLICE',
+                                data_columns=['YEAR'],
+                                target_column='VALUE',
+                            )
+                        )
+                        if not df_year_split.empty else None),
+                    day_split = (
+                        IntYearData(
+                            data=group_to_json(
+                                g=df_year_split,
+                                root_column='DAILYTIMEBRACKET',
+                                data_columns=['YEAR'],
+                                target_column='VALUE',
+                            )
+                        )
+                        if not df_day_split.empty else None),
+                    days_in_day_type = (
+                        IntIntIntData(
+                            data=group_to_json(
+                                g=df_year_split,
+                                root_column='SEASON',
+                                data_columns=['DAYTYPE','YEAR'],
+                                target_column='VALUE',
+                            )
+                        )
+                        if not df_days_in_day_type.empty else None),
+                    conversion_ld = (
+                        StringYearData(
+                            data=group_to_json(
+                                g=df_year_split,
+                                root_column='TIMESLICE',
+                                data_columns=['DAYTYPE'],
+                                target_column='VALUE',
+                            )
+                        )
+                        if not df_conversion_ld.empty else None),
+                    conversion_lh = (
+                        StringYearData(
+                            data=group_to_json(
+                                g=df_year_split,
+                                root_column='TIMESLICE',
+                                data_columns=['DAILYTIMEBRACKET'],
+                                target_column='VALUE',
+                            )
+                        )
+                        if not df_conversion_lh.empty else None),
+                    conversion_ls = (
+                        StringYearData(
+                            data=group_to_json(
+                                g=df_year_split,
+                                root_column='TIMESLICE',
+                                data_columns=['SEASON'],
+                                target_column='VALUE',
+                            )
+                        )
+                        if not df_conversion_ls.empty else None)
+                    )

--- a/src/osemosys/utils.py
+++ b/src/osemosys/utils.py
@@ -80,7 +80,9 @@ def makehash():
 
 def _fill_d(d, target_column, data_columns, t):
     try:
-        if len(data_columns) == 2:
+        if len(data_columns) == 1:
+            d[str(getattr(t, data_columns[0]))] = getattr(t, target_column)
+        elif len(data_columns) == 2:
             d[str(getattr(t, data_columns[0]))][str(getattr(t, data_columns[1]))] = getattr(
                 t, target_column
             )

--- a/src/osemosys/utils.py
+++ b/src/osemosys/utils.py
@@ -96,6 +96,7 @@ def _fill_d(d, target_column, data_columns, t):
             ][str(getattr(t, data_columns[3]))] = getattr(t, target_column)
         else:
             raise NotImplementedError
+        #TODO add case for where len(data_columns) == 5
     except Exception as e:
         print(t)
         print(target_column)
@@ -107,7 +108,7 @@ def _fill_d(d, target_column, data_columns, t):
 
 def group_to_json(
     g: pd.DataFrame,
-    root_column: str,
+    root_column: Optional[str] = None,
     target_column: str = "value",
     data_columns: Optional[List[str]] = None,
     default_nodes: List[str] = None,
@@ -123,11 +124,13 @@ def group_to_json(
         d = makehash()
 
     if not fill_zero:
-        for t in g.drop(columns=[root_column]).loc[g[target_column] != 0].itertuples():
-            _fill_d(d, target_column, data_columns, t)
-    else:
-        for t in g.drop(columns=[root_column]).itertuples():
-            _fill_d(d, target_column, data_columns, t)
+        g = g.loc[g[target_column] != 0]
+
+    if root_column is not None:
+        g = g.drop(columns=[root_column])
+
+    for t in g.itertuples():
+        _fill_d(d, target_column, data_columns, t)
 
     # https://github.com/ijl/orjson#opt_non_str_keys
     return orjson.loads(orjson.dumps(d, option=orjson.OPT_NON_STR_KEYS))

--- a/test_from_simplicity.py
+++ b/test_from_simplicity.py
@@ -10,7 +10,7 @@ comparison_directory = "simplicity_compare/"
 run_spec_object = RunSpec.from_simplicity(root_dir=root_dir)
 
 # type(run_spec_object) == <class RunSpec>
-run_spec_object.to_simplicity(comparison_directory=comparison_directory)
+run_spec_object.to_csv(comparison_directory=comparison_directory)
 
 comparison_files = glob.glob(comparison_directory + "*.csv")
 comparison_files = {Path(f).stem:f for f in comparison_files}

--- a/test_from_simplicity.py
+++ b/test_from_simplicity.py
@@ -7,10 +7,10 @@ root_dir = "test/model_three/"
 comparison_directory = "simplicity_compare/"
 
 # uses the class method on the base class to instantiate itself
-run_spec_object = RunSpec.from_simplicity(root_dir=root_dir)
+run_spec_object = RunSpec.from_otoole_csv(root_dir=root_dir)
 
 # type(run_spec_object) == <class RunSpec>
-run_spec_object.to_csv(comparison_directory=comparison_directory)
+run_spec_object.to_otoole_csv(comparison_directory=comparison_directory)
 
 comparison_files = glob.glob(comparison_directory + "*.csv")
 comparison_files = {Path(f).stem:f for f in comparison_files}


### PR DESCRIPTION
@Lkruitwagen Grateful for your review once more.

For this PR I've added the TimeDefinition data class, it's functions to read in and write csvs, and a few other tweaks to support this.

Running test_from_simplicity.py should now read in all data related to TimeDefinition, and write it out to CSVs again having gone through the schema checks.

**One output CSV is currently missing for the TimeDefinition data, that is DaysInDayType.**

https://github.com/Lkruitwagen/OSeMOSYS_linopy/commit/edba1a10b177fcff81ebe5b89af57841fc7e2673 - currently commented out the part that writes DaysInDayType

This is due to an issue I've been having in converting JSON type data dicts back to pandas dataframes. This has been ok for the data which only have up to 3 data columns, but given DaysInDayType has 4 data columns and it's corresponding JSON data dict has several nested layers, converting back to a dataframe is quite annoying.

Would be cool if we could discuss potential ways to address this. For now I'll move on to the read in part of the technology schemas.

